### PR TITLE
Update appx_manifest.dart

### DIFF
--- a/lib/src/appx_manifest.dart
+++ b/lib/src/appx_manifest.dart
@@ -50,6 +50,7 @@ class AppxManifest {
       ${_config.languages!.map((language) => '<Resource Language="$language" />').join('')}
     </Resources>
     <Dependencies>
+      <TargetDeviceFamily Name="MSIXCore.Desktop" MinVersion="${_config.osMinVersion}" MaxVersionTested="10.0.22621.1778" />
       <TargetDeviceFamily Name="Windows.Desktop" MinVersion="${_config.osMinVersion}" MaxVersionTested="10.0.22621.1778" />
     </Dependencies>
     <Capabilities>


### PR DESCRIPTION
Allows installer to use msix core on older versions of windows

msix core when installed allows msix files to be installed all the way back to Windows 7 and also newer Enterprise versions of Windows (10 at least) that currently don't support msix installers.